### PR TITLE
Added preset names for Profiles

### DIFF
--- a/src/routes/ConfigCardEditor.svelte
+++ b/src/routes/ConfigCardEditor.svelte
@@ -43,9 +43,9 @@
 
     function getPresetName(preset: any) {
         const initConfig = preset.events.find((e: any) => e.event === 0).config;
-        const regex = /--\[\[@sn\]\] self:gen\(([^\s]*)\)/;
+        const regex = /--\[\[@sn\]\] self:gen\(["']([^"']+)["']\)/;
 
-        const value = initConfig.match(regex)?.at(1).slice(1, -1);
+        const value = initConfig.match(regex)?.at(1);
         return value;
     }
 </script>

--- a/src/routes/ConfigCardEditor.svelte
+++ b/src/routes/ConfigCardEditor.svelte
@@ -40,6 +40,14 @@
         selected_config.set(undefined);
         selected_config.set({ id, presetIndex }); // Now set to the actual value
     }
+
+    function getPresetName(preset: any) {
+        const initConfig = preset.events.find((e: any) => e.event === 0).config;
+        const regex = /--\[\[@sn\]\] self:gen\(([^\s]*)\)/;
+
+        const value = initConfig.match(regex)?.at(1).slice(1, -1);
+        return value;
+    }
 </script>
 
 <button
@@ -100,13 +108,18 @@
     <div class="flex flex-col ml-4 gap-1 my-1">
         {#each data.configs as preset, index}
             {@const element = elements.find((e) => e.index === preset.controlElementNumber)}
+            {@const elementName = getPresetName(preset)}
             <svelte:self
                 isSelected={preset.controlElementNumber === $selected_config?.presetIndex}
                 data={{
                     type: element?.type,
-                    name: `Element ${index} (${
-                        elements[index].type.at(0)?.toUpperCase() + elements[index].type?.slice(1)
-                    })`
+                    name:
+                        typeof elementName !== "undefined"
+                            ? elementName
+                            : `Element ${index} (${
+                                  elements[index].type.at(0)?.toUpperCase() +
+                                  elements[index].type?.slice(1)
+                              })`
                 }}
                 on:click={() => {
                     handleSelection(data.id, preset.controlElementNumber);


### PR DESCRIPTION
Closes #103 

- Add Element Name action block for init (setup) event of control element
- Save the module configuration as a profile
- Open the saved profile
- The partial profile that contained the Element Name has a displayed name based on the Element Name action block