### PR TITLE
PC: Added Snippet saving feature

### DIFF
--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -15,7 +15,7 @@ export const BaseConfigSchema = z.object({
             patch: z.string()
         })
         .optional(),
-    configType: z.enum(["profile", "preset"]),
+    configType: z.enum(["profile", "preset", "snippet"]),
     configs: z.any(),
     owner: z.string().optional(),
     virtualPath: z.string().optional()

--- a/src/routes/ConfigCardEditor.svelte
+++ b/src/routes/ConfigCardEditor.svelte
@@ -19,7 +19,11 @@
     $: handleCompatibleConfigsChange($compatible_config_types);
 
     function handleCompatibleConfigsChange(types: string[]) {
-        compatible = types.includes(data.type);
+        if (data.configType === "snippet") {
+            compatible = true;
+        } else {
+            compatible = types.includes(data.type);
+        }
     }
 
     function handleToggle() {

--- a/src/routes/ConfigurationSave.svelte
+++ b/src/routes/ConfigurationSave.svelte
@@ -1,7 +1,8 @@
 <script lang="ts" context="module">
     export enum ConfigurationSaveType {
         MODULE = 0,
-        ELEMENT = 1
+        ELEMENT = 1,
+        SNIPPET = 2
     }
 
     enum ConfigurationSaveState {
@@ -104,25 +105,36 @@
 
 <container class="flex w-full">
     {#if state === ConfigurationSaveState.SELECT}
-        <div class="grid grid-cols-[1fr_1fr_auto] gap-2 w-full">
-            <button
-                class="flex w-full dark:bg-primary-700 dark:hover:bg-secondary items-center justify-center {selected ===
-                ConfigurationSaveType.ELEMENT
-                    ? 'border-white'
-                    : 'border-transparent'} border-opacity-75 border-2"
-                on:click={() => handleSelectionChange(ConfigurationSaveType.ELEMENT)}
-            >
-                {element} Element
-            </button>
-            <button
-                class="flex w-full dark:bg-primary-700 dark:hover:bg-secondary items-center justify-center {selected ===
-                ConfigurationSaveType.MODULE
-                    ? 'border-white'
-                    : 'border-transparent'} border-opacity-75 border-2"
-                on:click={() => handleSelectionChange(ConfigurationSaveType.MODULE)}
-            >
-                {module} Module
-            </button>
+        <div class="flex flex-row gap-2 w-full">
+            <div class="grid grid-flow-col w-full gap-2">
+                <button
+                    class="flex w-full dark:bg-primary-700 dark:hover:bg-secondary items-center justify-center {selected ===
+                    ConfigurationSaveType.ELEMENT
+                        ? 'border-white'
+                        : 'border-transparent'} border-opacity-75 border-2"
+                    on:click={() => handleSelectionChange(ConfigurationSaveType.ELEMENT)}
+                >
+                    {element} Element
+                </button>
+                <button
+                    class="flex w-full dark:bg-primary-700 dark:hover:bg-secondary items-center justify-center {selected ===
+                    ConfigurationSaveType.MODULE
+                        ? 'border-white'
+                        : 'border-transparent'} border-opacity-75 border-2"
+                    on:click={() => handleSelectionChange(ConfigurationSaveType.MODULE)}
+                >
+                    {module} Module
+                </button>
+                <button
+                    class="flex w-full dark:bg-primary-700 dark:hover:bg-secondary items-center justify-center {selected ===
+                    ConfigurationSaveType.SNIPPET
+                        ? 'border-white'
+                        : 'border-transparent'} border-opacity-75 border-2"
+                    on:click={() => handleSelectionChange(ConfigurationSaveType.SNIPPET)}
+                >
+                    Snippet
+                </button>
+            </div>
             <div class="flex flex-col gap-2 w-20">
                 <button
                     class="px-4 py-1 dark:bg-primary-700 dark:hover:bg-secondary"

--- a/src/routes/ConfigurationSave.svelte
+++ b/src/routes/ConfigurationSave.svelte
@@ -49,6 +49,10 @@
                 nameInputValue = `New ${module} Configuration`;
                 break;
             }
+            case ConfigurationSaveType.SNIPPET: {
+                nameInputValue = `New Snippet`;
+                break;
+            }
         }
     }
 
@@ -156,6 +160,8 @@
                     <span>{element} Configuration</span>
                 {:else if selected === ConfigurationSaveType.MODULE}
                     <span>{module} Configuration</span>
+                {:else if selected === ConfigurationSaveType.SNIPPET}
+                    <span>Snippet Name:</span>
                 {/if}
 
                 <input
@@ -164,7 +170,7 @@
                     bind:value={nameInputValue}
                     class="flex w-full p-2 bg-white dark:bg-primary-700
                         dark:placeholder-gray-400 text-md focus:outline-none"
-                    placeholder="Your Profile/Preset name..."
+                    placeholder="My Configuration..."
                 />
             </div>
             <div class="flex flex-col gap-2 w-20">

--- a/src/routes/EditorLayout.svelte
+++ b/src/routes/EditorLayout.svelte
@@ -117,21 +117,24 @@
     }
 
     async function createNewLocalConfigWithTheSelectedModulesConfigurationFromEditor(
-        type: "profile" | "preset",
+        type: "profile" | "preset" | "snippet",
         name: string
     ) {
-        const configResponse = await parentIframeCommunication({
-            windowPostMessageName: "getCurrenConfigurationFromEditor",
-            dataForParent: { configType: type }
-        });
-        configResponse.data.name = name;
-        if (configResponse.ok) {
+        try {
+            const configResponse = await parentIframeCommunication({
+                windowPostMessageName: "getCurrenConfigurationFromEditor",
+                dataForParent: { configType: type }
+            });
+            configResponse.data.name = name;
+
             const config = BaseConfigSchema.parse(configResponse.data);
             config.createdAt = new Date();
             const cm = get(config_manager);
             cm?.saveConfig(config, true).then((e) => {
                 filter_value.set(new FilterValue());
             });
+        } catch (e) {
+            console.error(e);
         }
     }
 
@@ -279,6 +282,10 @@
             }
             case ConfigurationSaveType.MODULE: {
                 createNewLocalConfigWithTheSelectedModulesConfigurationFromEditor("profile", name);
+                break;
+            }
+            case ConfigurationSaveType.SNIPPET: {
+                createNewLocalConfigWithTheSelectedModulesConfigurationFromEditor("snippet", name);
                 break;
             }
         }


### PR DESCRIPTION
Closes #116 
Connecting Editor: https://github.com/intechstudio/grid-editor/pull/975

Added ability to save snippets similiar to presets/profiles.

**NOTE:** To use the PC bould, a compatible editor is needed. (See above). 
**IMPORTANT:** Online builds of editor does not support snippet/preset/profile save.

### Usage

1. Select action blocks in action list
2. Click on + sing in profile cloud, and follow the procedure similiar to preset/profile save
3. To Load snippets on an event, drag and drop the snippet in Profile Cloud to destination similiar to regular action block drag and drop.

When no action blocks are selected, the snippet saving procedure can be done, but an error message prompts the user about the failed snippet saving (similiar to profile/preset save when no device is connected)