### PR TITLE
Optimized compatibility checking and added debouncing for filtering

### DIFF
--- a/src/lib/components/tree/ConfigTree.svelte
+++ b/src/lib/components/tree/ConfigTree.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { get } from "svelte/store";
+  import { get, writable, Writable } from "svelte/store";
   import { Sort, sort_key } from "./../../../routes/Sorter";
   import {
     filter_value,
@@ -36,10 +36,26 @@
 
   let treeProps: TreeProperties;
 
+  export function debounced<T>(store: Writable<T>, delay = 300) {
+    let timeout: ReturnType<typeof setTimeout>;
+    const debouncedStore = writable<T>(get(store));
+
+    store.subscribe((value) => {
+      clearTimeout(timeout);
+      timeout = setTimeout(() => {
+        debouncedStore.set(value);
+      }, delay);
+    });
+
+    return debouncedStore;
+  }
+
+  export const debounced_filter_value = debounced(filter_value, 300);
+
   $: {
     treeProps = buildProps(
       configs,
-      $filter_value,
+      $debounced_filter_value,
       $sort_key,
       $show_supported_only,
       $compatible_config_types,

--- a/src/routes/EditorLayout.svelte
+++ b/src/routes/EditorLayout.svelte
@@ -110,14 +110,13 @@
       }
 
       case "compatibleTypes": {
-        const current = get(compatible_config_types) as string[];
-        const next = event.data.compatibleTypes as string[];
+        const current = new Set(get(compatible_config_types) as string[]);
+        const next = new Set(event.data.compatibleTypes as string[]);
 
-        const arraysDiffer =
-          current.length !== next.length ||
-          current.some((v, i) => v !== next[i]);
+        const different =
+          current.size !== next.size || [...current].some((v) => !next.has(v));
 
-        if (arraysDiffer) {
+        if (different) {
           compatible_config_types.set(event.data.compatibleTypes);
         }
         break;


### PR DESCRIPTION
Closes #158

The root cause of laggy PC rendering is that the tree component is regenerated each time any of the following things change:

- PC content (e.g.: new config is added)
- The filters input text changes (e.g.: each keystroke)
- The sorting direction change
- The supported checkbox is toggled
- The compatibility list changes (e.g.: a differnet module/element is selected on a module)

Two of these can change a lot, causing a series of re-rendering of the tree:

- Filter value
- Compatibility list

The costly re-rendering can be reduced by addressing these issue in the following way:

- The compatibility list is only updated, if it actually changes. This is a minor issue, but can be distracting when navigating for example a BU16 module.
- Using a debounce store for triggering reactivity when the filter value changes. For example, do not instantly regenerate the tree for each key stroke, what some miliseconds (in this case 300) for regenerating the tree. (Maybe use a thinker to indicate progression?)