### PR TITLE
Use production Firebase database for nightly builds

### DIFF
--- a/.github/workflows/firebase-hosting-commit-prod.yml
+++ b/.github/workflows/firebase-hosting-commit-prod.yml
@@ -17,10 +17,10 @@ jobs:
           echo $(git log -5)
           touch .env
           echo PUBLIC_COMMIT_HASH=$(git log --format="%h" -n 1) >> .env
-          echo PUBLIC_APP_ENV=development >> .env  
-          echo PUBLIC_GOOGLE_CLIENT_ID=${{ secrets.PUBLIC_GOOGLE_CLIENT_ID_DEV }} >> .env
+          echo PUBLIC_APP_ENV=production >> .env
+          echo PUBLIC_GOOGLE_CLIENT_ID=${{ secrets.PUBLIC_GOOGLE_CLIENT_ID_PROD }} >> .env
           echo PUBLIC_CREATION_DATE=$(git log --format="%cd" --date=format:'%Y-%m-%d' -1) >> .env
-      - run: npm ci && npm run build && npm run build:webcomponent
+      - run: npm ci && npx svelte-kit sync && npm run build && npm run build:webcomponent
         env:
           WEB_COMPONENT_NAME: profile-cloud-nightly
       - uses: FirebaseExtended/action-hosting-deploy@v0


### PR DESCRIPTION
Switch nightly workflow to use production app env and Google client ID so the dev-hosted nightly site connects to the production Firestore and auth providers. Also add svelte-kit sync before build.