### PR TITLE
Fix responsive breakpoints for web component deployment

### DIFF
--- a/src/lib/components/tree/ProfileCloudTreeItem.svelte
+++ b/src/lib/components/tree/ProfileCloudTreeItem.svelte
@@ -97,6 +97,7 @@
 
 <style>
   .button {
+    container-type: inline-size;
     display: flex;
     flex-direction: row;
     gap: 0.5rem;
@@ -207,7 +208,7 @@
     white-space: nowrap;
   }
 
-  @media (max-width: 400px) {
+  @container (max-width: 400px) {
     .modified-date {
       display: none;
     }

--- a/src/routes/BrowserLayout.svelte
+++ b/src/routes/BrowserLayout.svelte
@@ -104,6 +104,7 @@
 <style>
   /* Main container */
   #main {
+    container-type: inline-size;
     display: flex;
     flex-direction: column;
     position: relative;
@@ -137,14 +138,14 @@
     gap: 1rem; /* gap-4 */
   }
 
-  @media (min-width: 768px) {
+  @container (min-width: 768px) {
     /* md:grid-cols-2 */
     .configs-grid {
       grid-template-columns: repeat(2, 1fr);
     }
   }
 
-  @media (min-width: 1024px) {
+  @container (min-width: 1024px) {
     /* lg:py-8 and lg:grid-cols-3 */
     .configs-grid {
       padding-top: 2rem;


### PR DESCRIPTION
## Summary
- Replace CSS `@media` queries with `@container` queries in `ProfileCloudTreeItem.svelte` and `BrowserLayout.svelte`
- `@media` queries respond to the viewport width, which doesn't work when the app is embedded as a web component inside another application (e.g. Grid Editor) — the viewport is the full browser window, not the component's panel
- `@container` queries respond to the nearest ancestor's container width, so breakpoints now trigger correctly based on the actual available space

## Test plan
- [ ] Verify the modified date hides in `ProfileCloudTreeItem` when the tree panel is narrower than 400px in the web component deployment
- [ ] Verify the config grid in `BrowserLayout` switches from 1 → 2 → 3 columns at the correct breakpoints in the web component deployment
- [ ] Verify the standalone app (non-web-component) still behaves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)